### PR TITLE
window.location.search hand through for addon configuration pages

### DIFF
--- a/addon/www/index.html
+++ b/addon/www/index.html
@@ -593,7 +593,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 						.attr('data-addon-config-url', addon.config_url)
 						.append($('<i class="setting icon">'), i18next.t('open_config'));
 					bconfig.click(function() {
-						var win = window.open(this.getAttribute('data-addon-config-url'), '_blank');
+						var win = window.open(this.getAttribute('data-addon-config-url') + window.location.search, '_blank');
 						win.focus();
 					});
 					


### PR DESCRIPTION
Hi!
Habe die Weitergabe des Querystrings beim Klick auf den Addon Konfiguration Button eingebaut, sonst konnte man die RedMatic Konfiguration nicht aufrufen, die prüft auf gültige Session...
Grüße,
Sebastian

PS.: Würde noch 2 Sachen vorschlagen, wenn Du möchtest kann ich Dir bei Gelegenheit dafür auch PRs machen:
* Session Prüfung für alle .cgi und die index.html
* Automatische Builds Deines Addons via Travis-CI mit anschließendem automatischen Upload des tar.gz auf die Github release page.